### PR TITLE
Speed up directory listing by factor 4-5 by improving getChildren function

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/fragments/ItemsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/fragments/ItemsFragment.kt
@@ -141,14 +141,15 @@ class ItemsFragment : android.support.v4.app.Fragment(), ItemsAdapter.ItemOperat
     }
 
     private fun getChildren(file: File): Int {
-        if (file.listFiles() == null)
+        var fileList = file.list()
+        if (fileList == null)
             return 0
 
         if (file.isDirectory) {
             return if (mShowHidden) {
-                file.listFiles()?.size ?: 0
+                fileList.size
             } else {
-                file.listFiles { file -> !file.isHidden }?.size ?: 0
+                fileList.count { fileName -> fileName[0] != '.' }
             }
         }
         return 0


### PR DESCRIPTION
The speed up is achieved by multiple changes:
1) Use list() instead of listFiles() function. The former only returns a String array
containing the relative pathnames, and therefore is faster and consumes less
memory.
2) The list() function should only be called once. In the previous implementation,
the function was called twice (for directories). The first time it was only checked
against null and then thrown away.
3) The Strings do not have a "isHidden" property, obviously. However, hidden
files can be easily distinguished by checking if the first character is a dot (".").

Performance tests were done in a directory with 12 sub-directories that have
about 900 children in total. The old implementation needed about 400-500 ms
to list the directory. With the new implementation, only 100ms are needed.