### PR TITLE
View directory with absolut path in EXTRA field instead of data

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
@@ -161,9 +161,12 @@ class MainActivity : SimpleActivity() {
     }
 
     private fun initFileManager() {
-        if (intent.action == Intent.ACTION_VIEW && intent.data != null) {
+        val absolutePath = intent.getStringExtra("org.openintents.extra.ABSOLUTE_PATH")
+        if (intent.action == Intent.ACTION_VIEW && (intent.data != null || absolutePath != null)) {
             val data = intent.data
-            if (data.scheme == "file") {
+            if (data == null && absolutePath != null) {
+                openPath(absolutePath);
+            } else if (data.scheme == "file") {
                 openPath(data.path)
             } else {
                 val path = getRealPathFromURI(data)


### PR DESCRIPTION
Applications targeting Android API 24+ can not put file:// URIs into the data
field. (The operating system will throw a FileUriExposedException).

To open the file manager from another app with the intent of viewing a
directory the path of said directory has to be communicated by other
means. Namely some kind of EXTRA field. What to name that field generally
doesn’t matter as long as the calling and the receiving application
use the same field name.

OpenIntents.org is a website dedicated to standardizing Intent Actions and
EXTRA fields.

http://www.openintents.org/action/android-intent-action-view/file-directory

The proposal from openintent is to call this field: org.openintents.extra.ABSOLUTE_PATH

Supporting applications on the calling side include
k3b/APhotoManager: https://github.com/k3b/APhotoManager/commit/f436c737a5014c37bc53d2901f2cf832cd24ed46#diff-599c68b20990d4ea35009a510d11e19dR49
Conversations: https://github.com/siacs/Conversations/commit/5f543e8314739e73173eacc74b43e2558cb17e36#diff-6aedab3ff8e4b75b71a581600beff0daR71

Supporting applications on the receiving side include:
OI File Manager