### PR TITLE
extract zip to correct path

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/adapters/ItemsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/adapters/ItemsAdapter.kt
@@ -426,10 +426,12 @@ class ItemsAdapter(activity: SimpleActivity, var listItems: MutableList<ListItem
             try {
                 val zipFile = ZipFile(it)
                 val entries = zipFile.entries()
+                val zipFileName = it.getFilenameFromPath()
+                val newFolderName = zipFileName.subSequence(0, zipFileName.length-4)
                 while (entries.hasMoreElements()) {
                     val entry = entries.nextElement()
                     val parentPath = it.getParentPath()
-                    val newPath = "$parentPath${entry.name.trimEnd('/')}"
+                    val newPath = "$parentPath/$newFolderName/${entry.name.trimEnd('/')}"
 
                     val resolution = getConflictResolution(conflictResolutions, newPath)
                     val doesPathExist = File(newPath).exists()


### PR DESCRIPTION
adds missing path seperator and extracts ./archive.zip to ./archive/
Issues: #308 #240 
Tested on LineageOS 16

Doesn't fix the "zip file is empty" exception mentioned in #308