### PR TITLE
Allow all mime-types when using the 'Save As' function

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,9 +90,7 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
 
-                <data android:mimeType="text/plain" />
-                <data android:mimeType="image/*" />
-                <data android:mimeType="video/*" />
+                <data android:mimeType="*/*" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
When sharing e.g. a pdf from another app, SimpleFileManager's 'Save as' is now visible for all mime-types.

Tested on a Google pixel with mp3, pdf files.

For reference: Amaze also doesn't restrict the mime type: [link](https://github.com/TeamAmaze/AmazeFileManager/blob/dfa277ef2ed4fba72660518b6f5f326dca8e602c/app/src/main/AndroidManifest.xml#L112)

fix #500 