### PR TITLE
Use the app wide view type on the recent files screen

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/adapters/ItemsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/adapters/ItemsAdapter.kt
@@ -54,7 +54,7 @@ import java.util.zip.ZipOutputStream
 
 class ItemsAdapter(
     activity: SimpleActivity, var listItems: MutableList<ListItem>, val listener: ItemOperationsListener?, recyclerView: MyRecyclerView,
-    val isPickMultipleIntent: Boolean, val swipeRefreshLayout: SwipeRefreshLayout?, itemClick: (Any) -> Unit
+    val isPickMultipleIntent: Boolean, val swipeRefreshLayout: SwipeRefreshLayout?, canHaveIndividualViewType: Boolean = true, itemClick: (Any) -> Unit
 ) :
     MyRecyclerViewAdapter(activity, recyclerView, itemClick), RecyclerViewFastScroller.OnPopupTextUpdate {
 
@@ -74,7 +74,11 @@ class ItemsAdapter(
     private var timeFormat = ""
 
     private val config = activity.config
-    private val viewType = config.getFolderViewType(listItems.firstOrNull { !it.isSectionTitle }?.mPath?.getParentPath() ?: "")
+    private val viewType = if (canHaveIndividualViewType) {
+        config.getFolderViewType(listItems.firstOrNull { !it.isSectionTitle }?.mPath?.getParentPath() ?: "")
+    } else {
+        config.viewType
+    }
     private val isListViewType = viewType == VIEW_TYPE_LIST
     private var displayFilenamesInGrid = config.displayFilenames
 

--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/fragments/RecentsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/fragments/RecentsFragment.kt
@@ -57,7 +57,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
             return
         }
 
-        ItemsAdapter(activity as SimpleActivity, recents, this, recents_list, isPickMultipleIntent, recents_swipe_refresh) {
+        ItemsAdapter(activity as SimpleActivity, recents, this, recents_list, isPickMultipleIntent, recents_swipe_refresh, false) {
             clickedPath((it as FileDirItem).path)
         }.apply {
             recents_list.adapter = this


### PR DESCRIPTION
The recent screen is a special case, it shouldn't respect the individual settings for the folders that contain files listed on this screen. 
closes #531