### PR TITLE
fix shortcut opening wrong tab

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
@@ -365,6 +365,8 @@ class MainActivity : SimpleActivity() {
             if (!File(data.path!!).isDirectory) {
                 tryOpenPathIntent(data.path!!, false, finishActivity = true)
             }
+
+            main_view_pager.currentItem = 0
         } else {
             openPath(config.homeFolder)
         }


### PR DESCRIPTION
# Notes
- ensure the first (files) tab is selected when opened from the shortcut

https://user-images.githubusercontent.com/25648077/195008891-6f62f535-f925-4d90-bd59-6a95bbf9103a.mp4

