### PR TITLE
Return `AndroidPdfViewer` based on `PDFium`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ android {
 
 dependencies {
     implementation 'com.github.SimpleMobileTools:Simple-Commons:30e6321592'
-    implementation 'com.github.esensar:AndroidPdfViewer:1b33733a2b'
+    implementation 'com.github.tibbi:AndroidPdfViewer:e6a533125b'
     implementation 'com.github.Stericson:RootTools:df729dcb13'
     implementation 'com.github.Stericson:RootShell:1.6'
     implementation 'com.alexvasilkov:gesture-views:2.5.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ android {
 
 dependencies {
     implementation 'com.github.SimpleMobileTools:Simple-Commons:30e6321592'
-    implementation 'com.github.tibbi:PdfViewPager:d2af24208d'
+    implementation 'com.github.esensar:AndroidPdfViewer:1b33733a2b'
     implementation 'com.github.Stericson:RootTools:df729dcb13'
     implementation 'com.github.Stericson:RootShell:1.6'
     implementation 'com.alexvasilkov:gesture-views:2.5.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:30e6321592'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:84c71fdcc1'
     implementation 'com.github.tibbi:AndroidPdfViewer:e6a533125b'
     implementation 'com.github.Stericson:RootTools:df729dcb13'
     implementation 'com.github.Stericson:RootShell:1.6'

--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
@@ -632,8 +632,7 @@ class MainActivity : SimpleActivity() {
     }
 
     private fun launchAbout() {
-        // TODO: Add PDFViewer license
-        val licenses = LICENSE_GLIDE or LICENSE_PATTERN or LICENSE_REPRINT or LICENSE_GESTURE_VIEWS or LICENSE_PDF_VIEW_PAGER or LICENSE_AUTOFITTEXTVIEW
+        val licenses = LICENSE_GLIDE or LICENSE_PATTERN or LICENSE_REPRINT or LICENSE_GESTURE_VIEWS or LICENSE_PDF_VIEWER or LICENSE_AUTOFITTEXTVIEW
 
         val faqItems = arrayListOf(
             FAQItem(R.string.faq_3_title_commons, R.string.faq_3_text_commons),

--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
@@ -632,6 +632,7 @@ class MainActivity : SimpleActivity() {
     }
 
     private fun launchAbout() {
+        // TODO: Add PDFViewer license
         val licenses = LICENSE_GLIDE or LICENSE_PATTERN or LICENSE_REPRINT or LICENSE_GESTURE_VIEWS or LICENSE_PDF_VIEW_PAGER or LICENSE_AUTOFITTEXTVIEW
 
         val faqItems = arrayListOf(

--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/PDFViewerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/PDFViewerActivity.kt
@@ -6,11 +6,9 @@ import android.graphics.Color
 import android.os.Bundle
 import android.print.PrintAttributes
 import android.print.PrintManager
-import android.view.View
 import android.view.WindowManager
-import androidx.viewpager2.widget.MarginPageTransformer
 import android.widget.RelativeLayout
-import androidx.viewpager2.widget.ViewPager2
+import com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.REAL_FILE_PATH
 import com.simplemobiletools.commons.helpers.isPiePlus
@@ -18,8 +16,6 @@ import com.simplemobiletools.filemanager.pro.R
 import com.simplemobiletools.filemanager.pro.extensions.hideSystemUI
 import com.simplemobiletools.filemanager.pro.extensions.showSystemUI
 import com.simplemobiletools.filemanager.pro.helpers.PdfDocumentAdapter
-import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter
-import es.voghdev.pdfviewpager.library.adapter.PdfErrorHandler
 import kotlinx.android.synthetic.main.activity_pdf_viewer.*
 
 class PDFViewerActivity : SimpleActivity() {
@@ -95,21 +91,17 @@ class PDFViewerActivity : SimpleActivity() {
             return
         }
 
-        val clickListener = View.OnClickListener {
-            toggleFullScreen()
-        }
-
-        val errorHandler = PdfErrorHandler { throwable -> showErrorToast(throwable.toString()) }
-
-        pdf_viewer.setPageTransformer(MarginPageTransformer(resources.getDimension(R.dimen.activity_margin).toInt()))
-        pdf_viewer.orientation = ViewPager2.ORIENTATION_VERTICAL
-        try {
-            pdf_viewer.adapter = PDFPagerAdapter(this, clickListener, errorHandler, uri.toString(), getProperBackgroundColor())
-        } catch (e: Exception) {
-            showErrorToast(e)
-            finish()
-            return
-        }
+        val primaryColor = getProperPrimaryColor()
+        pdf_viewer.setBackgroundColor(getProperBackgroundColor())
+        pdf_viewer.fromUri(uri)
+            .scrollHandle(DefaultScrollHandle(this, primaryColor.getContrastColor(), primaryColor))
+            .spacing(15)
+            .onTap { toggleFullScreen() }
+            .onError {
+                showErrorToast(it.localizedMessage?.toString() ?: getString(R.string.unknown_error_occurred))
+                finish()
+            }
+            .load()
 
         showSystemUI(true)
 

--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/PDFViewerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/PDFViewerActivity.kt
@@ -8,10 +8,9 @@ import android.print.PrintAttributes
 import android.print.PrintManager
 import android.view.View
 import android.view.WindowManager
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.viewpager2.widget.MarginPageTransformer
+import android.widget.RelativeLayout
 import androidx.viewpager2.widget.ViewPager2
-import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.REAL_FILE_PATH
 import com.simplemobiletools.commons.helpers.isPiePlus
@@ -59,6 +58,7 @@ class PDFViewerActivity : SimpleActivity() {
     }
 
     private fun setupMenu() {
+        (pdf_viewer_appbar.layoutParams as RelativeLayout.LayoutParams).topMargin = statusBarHeight
         pdf_viewer_toolbar.menu.apply {
             findItem(R.id.menu_print).isVisible = realFilePath.isNotEmpty()
             findItem(R.id.menu_print).setOnMenuItemClickListener {
@@ -71,29 +71,20 @@ class PDFViewerActivity : SimpleActivity() {
             finish()
         }
 
-        setupViewOffsets()
-        val primaryColor = getProperPrimaryColor()
-        page_counter.background?.applyColorFilter(primaryColor)
-        page_counter.setTextColor(primaryColor.getContrastColor())
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        setupViewOffsets()
-    }
-
-    private fun setupViewOffsets() {
-        val pageCounterMargin = resources.getDimension(R.dimen.normal_margin).toInt()
-        (pdf_viewer_appbar.layoutParams as ConstraintLayout.LayoutParams).topMargin = statusBarHeight
         if (!portrait && navigationBarOnSide && navigationBarWidth > 0) {
             pdf_viewer_appbar.setPadding(0, 0, navigationBarWidth, 0)
         } else {
             pdf_viewer_appbar.setPadding(0, 0, 0, 0)
         }
+    }
 
-        (page_counter.layoutParams as ConstraintLayout.LayoutParams).apply {
-            rightMargin = navigationBarWidth + pageCounterMargin
-            bottomMargin = navigationBarHeight + pageCounterMargin
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        (pdf_viewer_appbar.layoutParams as RelativeLayout.LayoutParams).topMargin = statusBarHeight
+        if (!portrait && navigationBarOnSide && navigationBarWidth > 0) {
+            pdf_viewer_appbar.setPadding(0, 0, navigationBarWidth, 0)
+        } else {
+            pdf_viewer_appbar.setPadding(0, 0, 0, 0)
         }
     }
 
@@ -120,25 +111,12 @@ class PDFViewerActivity : SimpleActivity() {
             return
         }
 
-        pdf_viewer.registerOnPageChangeCallback(object : OnPageChangeCallback() {
-            override fun onPageSelected(position: Int) {
-                updatePageCounter(position)
-            }
-        })
-
-        updatePageCounter(0)
-        page_counter.beVisible()
-
         showSystemUI(true)
 
         val filename = getFilenameFromUri(uri)
         if (filename.isNotEmpty()) {
             pdf_viewer_toolbar.title = filename
         }
-    }
-
-    private fun updatePageCounter(position: Int) {
-        page_counter.text = "${position + 1} / ${pdf_viewer.adapter?.itemCount}"
     }
 
     private fun printText() {
@@ -160,7 +138,6 @@ class PDFViewerActivity : SimpleActivity() {
             showSystemUI(true)
         }
 
-        page_counter.animate().alpha(newAlpha).start()
         top_shadow.animate().alpha(newAlpha).start()
         pdf_viewer_appbar.animate().alpha(newAlpha).withStartAction {
             if (newAlpha == 1f) {

--- a/app/src/main/res/layout/activity_pdf_viewer.xml
+++ b/app/src/main/res/layout/activity_pdf_viewer.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/pdf_viewer_wrapper"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <androidx.viewpager2.widget.ViewPager2
@@ -16,28 +15,18 @@
         android:id="@+id/top_shadow"
         android:layout_width="match_parent"
         android:layout_height="@dimen/top_shadow_height"
+        android:layout_alignParentTop="true"
         android:background="@drawable/gradient_background_flipped"
-        android:contentDescription="@null"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/page_counter"
-        style="@style/ColoredButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:text="1/3" />
+        android:contentDescription="@null" />
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/pdf_viewer_appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
         android:background="@android:color/transparent"
         android:elevation="0dp"
-        app:elevation="0dp"
-        app:layout_constraintTop_toTopOf="parent">
+        app:elevation="0dp">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/pdf_viewer_toolbar"
@@ -47,4 +36,4 @@
             app:navigationIcon="@drawable/ic_arrow_left_vector" />
 
     </com.google.android.material.appbar.AppBarLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_pdf_viewer.xml
+++ b/app/src/main/res/layout/activity_pdf_viewer.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <androidx.viewpager2.widget.ViewPager2
+    <com.github.barteksc.pdfviewer.PDFView
         android:id="@+id/pdf_viewer"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION
This PR returns previously used `AndroidPdfViewer` based on updated `PDFium` which should no longer have security vulnerabilities previously reported (https://github.com/SimpleMobileTools/Simple-File-Manager/issues/708). Currently there doesn't seem to be any need for further updates in the app or library code other than what was already done in https://github.com/tibbi/PdfiumAndroid/pull/1.

## TODO

- [x] Wait for https://github.com/tibbi/PdfiumAndroid/pull/1 and update https://github.com/tibbi/AndroidPdfViewer with new ref
- [x] Wait for https://github.com/tibbi/AndroidPdfViewer/pull/1 to update ref in dependencies
- [x] Restore license for AndroidPdfViewer into https://github.com/SimpleMobileTools/Simple-Commons (https://github.com/SimpleMobileTools/Simple-Commons/pull/1722)
- [x] Ensure vulnerability scanner will not complain about this updated version (should not happen, since it is manually checked and pdfium is really updated)