### PR TITLE
Quick fix: Use same size grid icon size for folders and files

### DIFF
--- a/app/src/main/res/layout/item_dir_grid.xml
+++ b/app/src/main/res/layout/item_dir_grid.xml
@@ -21,10 +21,11 @@
 
         <ImageView
             android:id="@+id/item_icon"
-            android:layout_width="@dimen/grid_view_icon_size"
-            android:layout_height="@dimen/grid_view_icon_size"
-            android:layout_centerHorizontal="true"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:adjustViewBounds="true"
+            android:layout_centerHorizontal="true"
+            android:padding="@dimen/small_margin"
             android:src="@drawable/ic_folder_vector" />
 
         <TextView


### PR DESCRIPTION
I thought since most file managers (e.g. nautilus) use the same icon size for folders and files so we should too.

### Before:

<img src="https://github.com/SimpleMobileTools/Simple-File-Manager/assets/36371707/24576ea6-7df7-4266-9287-7db2fccafd6a" width=200 /> <img src="https://github.com/SimpleMobileTools/Simple-File-Manager/assets/36371707/9f5a5ad5-2f0a-4162-a6d4-d00098111641" width=200 />

### After:
<img src="https://github.com/SimpleMobileTools/Simple-File-Manager/assets/36371707/a13b1685-2125-41e8-be7a-b9e687275d42" width=200 /> <img src="https://github.com/SimpleMobileTools/Simple-File-Manager/assets/36371707/cf0e706e-8cd6-4d73-8b0d-d6523bbb5a99" width=200 /> 


