### PR TITLE
Set intent data into fragments before starting them

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/activities/MainActivity.kt
@@ -373,24 +373,6 @@ class MainActivity : SimpleActivity() {
             openPath(config.homeFolder)
         }
 
-        val isPickRingtoneIntent = intent.action == RingtoneManager.ACTION_RINGTONE_PICKER
-        val isGetContentIntent = intent.action == Intent.ACTION_GET_CONTENT || intent.action == Intent.ACTION_PICK
-        val isCreateDocumentIntent = intent.action == Intent.ACTION_CREATE_DOCUMENT
-        val allowPickingMultipleIntent = intent.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
-        val getContentMimeType = if (isGetContentIntent) {
-            intent.type ?: ""
-        } else {
-            ""
-        }
-
-        getAllFragments().forEach {
-            it?.isGetRingtonePicker = isPickRingtoneIntent
-            it?.isPickMultipleIntent = allowPickingMultipleIntent
-            it?.isGetContentIntent = isGetContentIntent
-            it?.wantedMimeType = getContentMimeType
-            it?.updateIsCreateDocumentIntent(isCreateDocumentIntent)
-        }
-
         if (refreshRecents) {
             recents_fragment?.refreshFragment()
         }

--- a/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/adapters/ViewPagerAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/filemanager/pro/adapters/ViewPagerAdapter.kt
@@ -1,5 +1,7 @@
 package com.simplemobiletools.filemanager.pro.adapters
 
+import android.content.Intent
+import android.media.RingtoneManager
 import android.view.View
 import android.view.ViewGroup
 import androidx.viewpager.widget.PagerAdapter
@@ -19,6 +21,22 @@ class ViewPagerAdapter(val activity: SimpleActivity, val tabsToShow: ArrayList<I
         container.addView(view)
 
         (view as MyViewPagerFragment).apply {
+            val isPickRingtoneIntent = activity.intent.action == RingtoneManager.ACTION_RINGTONE_PICKER
+            val isGetContentIntent = activity.intent.action == Intent.ACTION_GET_CONTENT || activity.intent.action == Intent.ACTION_PICK
+            val isCreateDocumentIntent = activity.intent.action == Intent.ACTION_CREATE_DOCUMENT
+            val allowPickingMultipleIntent = activity.intent.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
+            val getContentMimeType = if (isGetContentIntent) {
+                activity.intent.type ?: ""
+            } else {
+                ""
+            }
+
+            this.isGetRingtonePicker = isPickRingtoneIntent
+            this.isPickMultipleIntent = allowPickingMultipleIntent
+            this.isGetContentIntent = isGetContentIntent
+            this.wantedMimeType = getContentMimeType
+            this.updateIsCreateDocumentIntent(isCreateDocumentIntent)
+
             setupFragment(activity)
             onResume(activity.getProperTextColor())
         }


### PR DESCRIPTION
This ensures that fragments have all data needed before doing initial data loading. This will ensure that Recents tab properly filters files by mime type immediately, instead of only after doing a pull to refresh.